### PR TITLE
v3.3.8

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-    build: or-tools
-aggregate_check: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+channels:
+    build: or-tools
+aggregate_check: false

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,15 +12,17 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: true  # [py<36]
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
+    - setuptools
+    - wheel
   run:
-    - python >=3.6
+    - python
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,9 +31,16 @@ test:
 
 about:
   home: https://github.com/python/typeshed
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://typing.readthedocs.io/
   summary: Typing stubs for futures
+  description: |
+    This is a PEP 561 type stub package for the futures package. 
+    It can be used by type-checking tools like mypy, PyCharm, 
+    pytype etc. to check code that uses futures.
   license: Apache-2.0 AND MIT
   license_file: LICENSE
+  license_family: Apache
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,14 @@ requirements:
     - python
 
 test:
+  requires:
+    - pip
+  imports:
+    - concurrent.futures
   commands:
-    - test -f $SP_DIR/concurrent-python2-stubs/futures/__init__.pyi
+    - test -f $SP_DIR/concurrent-python2-stubs/futures/__init__.pyi  # [not win]
+    - if not exist %SP_DIR%\\concurrent-python2-stubs\\futures\\__init__.pyi exit 1 # [win]
+    - pip check
 
 
 about:


### PR DESCRIPTION
# types-futures v3.3.8

`or-tools` -> `mypy-protobuf` -> `types-protobuf` -> `types-futures`

https://pypi.org/project/types-futures/

## Notes
- This is a new feedstock needed to eventually build or-tools
- Source appears to no longer be at https://github.com/python/typeshed/tree/master/stubs/futures

